### PR TITLE
ci(redfish): run Redfish-Interop-Validator in CI against fake clients

### DIFF
--- a/.github/workflows/redfish-interop.yml
+++ b/.github/workflows/redfish-interop.yml
@@ -1,0 +1,109 @@
+name: Redfish Interop
+
+# Runs the DMTF Redfish-Interop-Validator against the Redfish API served by
+# hack/redfish/interopserver (the real VirtualMachineResourceManager on
+# in-memory fake clients — no cluster, no KubeVirt). On PRs the base ref is
+# validated too, and the step summary diffs the two runs: regressions
+# introduced vs. failures fixed by the PR.
+# Gating: the job fails when the PR introduces NEW failures vs. the base run
+# (--fail-on-introduced). Without a base run (workflow_dispatch, or a base ref
+# predating the interop tooling) the report is informational only.
+# Local equivalent: make redfish-interop.
+
+on:
+  pull_request:
+    paths:
+      - "pkg/redfish/**"
+      - "pkg/resourcemanager/**"
+      - "pkg/generated/redfish/**"
+      - "pkg/session/**"
+      - "hack/redfish/**"
+      - ".github/workflows/redfish-interop.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: redfish-interop-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  PROFILE: hack/redfish/profiles/OpenStackIronicProfile.v1_2_0.json
+  VALIDATOR_VERSION: "2.3.6"
+
+jobs:
+  interop:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      # On pull_request events this is the synthetic merge commit, i.e. the
+      # post-merge result.
+      - name: Check out PR head
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install Redfish-Interop-Validator
+        run: pip install "redfish_interop_validator==${{ env.VALIDATOR_VERSION }}"
+
+      - name: Validate PR head
+        env:
+          LOGDIR: logs/head
+          # A failed validation must not fail this step: the base run and the
+          # Report gate come after. Build/readiness failures still fail it.
+          EXIT_WITH_VALIDATOR: "0"
+        run: hack/redfish/run-interop.sh
+
+      - name: Check out base ref
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.base_ref }}
+          path: base
+
+      - name: Validate base ref
+        if: github.event_name == 'pull_request'
+        env:
+          # Absolute paths: the script cds into base/, and base refs may not
+          # carry the vendored profile yet.
+          LOGDIR: ${{ github.workspace }}/logs/base
+          PROFILE: ${{ github.workspace }}/${{ env.PROFILE }}
+          EXIT_WITH_VALIDATOR: "0"
+        run: |
+          # Base refs from before the interop tooling existed can't be compared.
+          if [ ! -x base/hack/redfish/run-interop.sh ]; then
+            echo "Base ref has no hack/redfish/run-interop.sh; skipping base run."
+            exit 0
+          fi
+          base/hack/redfish/run-interop.sh
+
+      - name: Report
+        # pipefail: the default `bash -e` would let tee swallow the diff's
+        # exit code and the regression gate would never fail the step.
+        shell: bash -eo pipefail {0}
+        # tee: also keep the report in the step log — a bare "exit code 1"
+        # with the detail only on the Job Summary page reads like an
+        # infrastructure error, not a gate decision.
+        run: |
+          if [ -d logs/base ]; then
+            python3 hack/redfish/interop-diff.py --fail-on-introduced logs/head logs/base | tee -a "$GITHUB_STEP_SUMMARY"
+          else
+            python3 hack/redfish/interop-diff.py logs/head | tee -a "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload validator logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: redfish-interop-logs
+          path: logs/
+          retention-days: 14

--- a/.github/workflows/redfish-interop.yml
+++ b/.github/workflows/redfish-interop.yml
@@ -1,10 +1,13 @@
-name: Redfish Interop
+name: Redfish Interop (Ironic)
 
 # Runs the DMTF Redfish-Interop-Validator against the Redfish API served by
 # hack/redfish/interopserver (the real VirtualMachineResourceManager on
 # in-memory fake clients — no cluster, no KubeVirt). On PRs the base ref is
 # validated too, and the step summary diffs the two runs: regressions
 # introduced vs. failures fixed by the PR.
+# The profile under test is Ironic's OpenStackIronicProfile v1.2.0. Other
+# provisioning software can be covered later once they provide their own
+# profiles.
 # Gating: the job fails when the PR introduces NEW failures vs. the base run
 # (--fail-on-introduced). Without a base run (workflow_dispatch, or a base ref
 # predating the interop tooling) the report is informational only.
@@ -40,15 +43,15 @@ jobs:
       # On pull_request events this is the synthetic merge commit, i.e. the
       # post-merge result.
       - name: Check out PR head
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.x"
 
@@ -65,7 +68,7 @@ jobs:
 
       - name: Check out base ref
         if: github.event_name == 'pull_request'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.base_ref }}
           path: base
@@ -101,9 +104,12 @@ jobs:
           fi
 
       - name: Upload validator logs
+        # always(): artifacts matter most when earlier steps fail — a gate
+        # failure (new regressions) or an infra failure in a validate step is
+        # exactly when the full validator logs are needed for diagnosis.
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
-          name: redfish-interop-logs
+          name: redfish-interop-ironic-logs
           path: logs/
           retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ Dockerfile.cross
 
 # Redfish schema bundle files
 hack/DSP8010_*
+
+# Local Redfish interop validator output (make redfish-interop)
+logs/

--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,10 @@ download-schema: ## Download the Redfish schema.
 generate-redfish-api: ## Generate Redfish API server.
 	./hack/redfish/generate.sh
 
+.PHONY: redfish-interop
+redfish-interop: ## Run the Redfish Interop Validator locally against the fake-client interopserver.
+	./hack/redfish/run-interop.sh
+
 .PHONY: fmt
 fmt: ## Run go fmt against code.
 	go fmt ./...

--- a/hack/redfish/interop-diff.py
+++ b/hack/redfish/interop-diff.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Diff two Redfish-Interop-Validator run directories.
+
+Usage: interop-diff.py [--fail-on-introduced] HEAD_DIR [BASE_DIR]
+
+Each directory holds one validator run: stdout.txt (captured validator stdout,
+carrying the Results Summary table) and ConformanceLog_*.txt (carrying the
+verdict lines). FAIL verdicts are logged at ERROR level as
+"ERROR - <msg> ... <verdict> at <uri>", each appearing both inline and in the
+closing listing, hence the set dedupe.
+
+Prints a markdown summary to stdout: result counts side by side, then the
+ERROR lines unique to each run ("introduced" / "fixed"). With
+--fail-on-introduced, exits 1 when HEAD_DIR has ERROR lines BASE_DIR does not;
+without BASE_DIR every HEAD_DIR error counts as introduced (nothing to prove
+it pre-existing).
+"""
+
+import argparse
+import glob
+import os
+import re
+import sys
+
+SUMMARY_RE = re.compile(r"^\|\s*(Pass|Fail|Warning|Not Tested)\s*\|\s*(\d+)\s*\|", re.M)
+ERROR_RE = re.compile(r"^ERROR - (.*?)(?:\s*\.\.\.\s*)?$")
+RESULT_ORDER = ["Pass", "Fail", "Warning", "Not Tested"]
+
+
+def parse(logdir):
+    counts, errors = {}, set()
+
+    stdout_path = os.path.join(logdir, "stdout.txt")
+    if os.path.exists(stdout_path):
+        with open(stdout_path, errors="replace") as f:
+            for name, count in SUMMARY_RE.findall(f.read()):
+                counts[name] = int(count)
+
+    for path in glob.glob(os.path.join(logdir, "ConformanceLog_*.txt")):
+        with open(path, errors="replace") as f:
+            for line in f:
+                m = ERROR_RE.match(line)
+                if m:
+                    errors.add(m.group(1))
+    return counts, errors
+
+
+def fmt_count(counts, key):
+    return str(counts[key]) if key in counts else "n/a"
+
+
+def fmt_delta(head, base, key):
+    if key not in head or key not in base:
+        return ""
+    delta = head[key] - base[key]
+    return f"{delta:+d}" if delta else "0"
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--fail-on-introduced", action="store_true",
+                        help="exit 1 if HEAD_DIR has failures BASE_DIR does not "
+                             "(without BASE_DIR: any HEAD_DIR failure)")
+    parser.add_argument("head_dir")
+    parser.add_argument("base_dir", nargs="?")
+    args = parser.parse_args()
+
+    head_counts, head_errors = parse(args.head_dir)
+    base_counts, base_errors = parse(args.base_dir) if args.base_dir else ({}, set())
+    introduced = sorted(head_errors - base_errors)
+
+    # Fail>0 with no parsed ERROR lines means the validator's log format
+    # drifted from what parse() expects (verified against 2.3.6); without
+    # this warning --fail-on-introduced would pass vacuously.
+    if head_counts.get("Fail", 0) > 0 and not head_errors:
+        print("**Warning:** summary reports Fail > 0 but no ERROR lines were parsed "
+              "from ConformanceLog_*.txt — validator log format may have changed, "
+              "the failure lists below may be incomplete.\n")
+
+    print("## Redfish Interop Validator\n")
+    if args.base_dir:
+        print("| Result | base | PR head | delta |")
+        print("|--------|-----:|--------:|------:|")
+        for key in RESULT_ORDER:
+            print(f"| {key} | {fmt_count(base_counts, key)} | "
+                  f"{fmt_count(head_counts, key)} | {fmt_delta(head_counts, base_counts, key)} |")
+        print()
+
+        fixed = sorted(base_errors - head_errors)
+        print(f"### Introduced by this PR ({len(introduced)})\n")
+        print("\n".join(f"- `{e}`" for e in introduced) or "- none", end="\n\n")
+        print(f"### Fixed by this PR ({len(fixed)})\n")
+        print("\n".join(f"- `{e}`" for e in fixed) or "- none", end="\n\n")
+    else:
+        print("| Result | Count |")
+        print("|--------|------:|")
+        for key in RESULT_ORDER:
+            print(f"| {key} | {fmt_count(head_counts, key)} |")
+        print()
+        print(f"### Failures ({len(introduced)})\n")
+        print("\n".join(f"- `{e}`" for e in introduced) or "- none", end="\n\n")
+
+    if os.environ.get("GITHUB_ACTIONS"):
+        print("Full detail: see the uploaded `redfish-interop-logs` artifact "
+              "(InteropHtmlLog per run).")
+    else:
+        print(f"Full detail: InteropHtmlLog under `{args.head_dir}`.")
+
+    if args.fail_on_introduced and introduced:
+        print(f"\n**Regression gate: {len(introduced)} introduced failure(s).**")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hack/redfish/interop-diff.py
+++ b/hack/redfish/interop-diff.py
@@ -101,7 +101,7 @@ def main():
         print("\n".join(f"- `{e}`" for e in introduced) or "- none", end="\n\n")
 
     if os.environ.get("GITHUB_ACTIONS"):
-        print("Full detail: see the uploaded `redfish-interop-logs` artifact "
+        print("Full detail: see the uploaded `redfish-interop-ironic-logs` artifact "
               "(InteropHtmlLog per run).")
     else:
         print(f"Full detail: InteropHtmlLog under `{args.head_dir}`.")

--- a/hack/redfish/interopserver/main.go
+++ b/hack/redfish/interopserver/main.go
@@ -23,7 +23,7 @@ import (
 	kubevirtv1 "kubevirt.io/api/core/v1"
 	cdifake "kubevirt.io/client-go/containerizeddataimporter/fake"
 	kvfake "kubevirt.io/client-go/kubevirt/fake"
-	crffake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	crfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	bmcv1 "kubevirt.io/kubevirtbmc/api/bmc/v1beta1"
 	"kubevirt.io/kubevirtbmc/pkg/redfish"
@@ -73,7 +73,7 @@ func newResourceManager(ctx context.Context) (*resourcemanager.VirtualMachineRes
 
 	virtClient := kvfake.NewSimpleClientset(vm)
 	cdiClient := cdifake.NewSimpleClientset()
-	bmcClient := crffake.NewClientBuilder().WithScheme(scheme).WithObjects(bmc).Build()
+	bmcClient := crfake.NewClientBuilder().WithScheme(scheme).WithObjects(bmc).Build()
 
 	rm := resourcemanager.NewVirtualMachineResourceManager(virtClient, cdiClient, bmcClient, vmName)
 	if err := rm.Initialize(ctx, namespace, vmName); err != nil {

--- a/hack/redfish/interopserver/main.go
+++ b/hack/redfish/interopserver/main.go
@@ -1,0 +1,102 @@
+// Command interopserver serves the kubevirtbmc Redfish API backed by the real
+// VirtualMachineResourceManager running on in-memory fake clients (client-go /
+// controller-runtime fakes — no apiserver, no KubeVirt), so the DMTF
+// Redfish-Interop-Validator exercises production read paths in CI instead of
+// a hand-maintained stub that can drift from them. Write actions land on the
+// fakes and never fail: the interop validator only GETs.
+//
+// Swapping the fakes for envtest (real apiserver via setup-envtest) only
+// changes client construction below; it buys API-semantics realism (schema
+// validation, status subresource) that the validator's read-only traversal
+// does not exercise.
+package main
+
+import (
+	"context"
+	"os/signal"
+	"syscall"
+
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+	cdifake "kubevirt.io/client-go/containerizeddataimporter/fake"
+	kvfake "kubevirt.io/client-go/kubevirt/fake"
+	crffake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	bmcv1 "kubevirt.io/kubevirtbmc/api/bmc/v1beta1"
+	"kubevirt.io/kubevirtbmc/pkg/redfish"
+	"kubevirt.io/kubevirtbmc/pkg/resourcemanager"
+)
+
+const (
+	bmcUser     = "admin"
+	bmcPassword = "password"
+	port        = 8000
+	namespace   = "interop"
+	vmName      = "vm"
+)
+
+// newResourceManager wires the production resource manager to fakes preloaded
+// with a running VM (one bootOrder-1 disk, no boot override) and its
+// VirtualMachineBMC CR.
+func newResourceManager(ctx context.Context) (*resourcemanager.VirtualMachineResourceManager, error) {
+	bootOrder := uint(1)
+	vm := &kubevirtv1.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: vmName, UID: types.UID("3f5b8c2e-7a1d-4e6b-9c0f-2a4b6d8e0f1a")},
+		Spec: kubevirtv1.VirtualMachineSpec{
+			Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+				Spec: kubevirtv1.VirtualMachineInstanceSpec{
+					Domain: kubevirtv1.DomainSpec{
+						Devices: kubevirtv1.Devices{
+							Disks: []kubevirtv1.Disk{{
+								Name:       "rootdisk",
+								BootOrder:  &bootOrder,
+								DiskDevice: kubevirtv1.DiskDevice{Disk: &kubevirtv1.DiskTarget{}},
+							}},
+						},
+					},
+				},
+			},
+		},
+		Status: kubevirtv1.VirtualMachineStatus{Ready: true},
+	}
+
+	scheme := runtime.NewScheme()
+	if err := bmcv1.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
+	bmc := &bmcv1.VirtualMachineBMC{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: vmName},
+	}
+
+	virtClient := kvfake.NewSimpleClientset(vm)
+	cdiClient := cdifake.NewSimpleClientset()
+	bmcClient := crffake.NewClientBuilder().WithScheme(scheme).WithObjects(bmc).Build()
+
+	rm := resourcemanager.NewVirtualMachineResourceManager(virtClient, cdiClient, bmcClient, vmName)
+	if err := rm.Initialize(ctx, namespace, vmName); err != nil {
+		return nil, err
+	}
+	return rm, nil
+}
+
+func main() {
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	rm, err := newResourceManager(ctx)
+	if err != nil {
+		logrus.Fatal(err)
+	}
+
+	emulator := redfish.NewEmulator(ctx, port, bmcUser, bmcPassword, rm)
+	if err := emulator.Run(); err != nil {
+		logrus.Fatal(err)
+	}
+	logrus.Infof("Redfish interop test server listening on :%d (credentials %s/%s)", port, bmcUser, bmcPassword)
+
+	<-ctx.Done()
+	emulator.Stop()
+}

--- a/hack/redfish/profiles/OpenStackIronicProfile.v1_2_0.json
+++ b/hack/redfish/profiles/OpenStackIronicProfile.v1_2_0.json
@@ -1,0 +1,586 @@
+{
+    "License": "Apache License, Version 2.0. For full text, see link: http://www.apache.org/licenses/LICENSE-2.0",
+    "SchemaDefinition": "RedfishInteroperabilityProfile.v1_8_0",
+    "ProfileName": "OpenStackIronicProfile",
+    "ProfileVersion": "1.2.0",
+    "Purpose": "Specifies the OpenStack Ironic vendor-independent Redfish service requirements, typically offered by a baseboard management controller (BMC).",
+    "OwningEntity": "Ironic community",
+    "ContactInfo": "openstack-discuss@lists.openstack.org",
+    "Protocol": {
+        "MinVersion": "1.6.0"
+    },
+    "Resources": {
+        "Bios": {
+            "Purpose": "Allows reading or changing BIOS settings.",
+            "ReadRequirement": "Recommended",
+            "PropertyRequirements": {
+                "Attributes": {
+                    "Purpose": "Current BIOS settings."
+                },
+                "AttributeRegistry": {
+                    "Purpose": "Name of the registry with the schema of BIOS settings.",
+                    "ReadRequirement": "Recommended"
+                },
+                "@Redfish.Settings": {
+                    "PropertyRequirements": {
+                        "ETag": {
+                            "ReadRequirement": "Recommended"
+                        },
+                        "Messages": {
+                            "Purpose": "Used to determine success or failure.",
+                            "ReadRequirement": "Recommended"
+                        },
+                        "SettingsObject": {
+                            "Purpose": "Provides a link to the actually updated object.",
+                            "Comparison": "LinkToResource",
+                            "Values": ["Bios"]
+                        },
+                        "SupportedApplyTimes": {
+                            "Purpose": "Determines whether update is immediate or needs a reboot.",
+                            "ReadRequirement": "Recommended",
+                            "MinSupportValues": [
+                                "OnReset"
+                            ]
+                        }
+                    }
+                }
+            },
+            "ActionRequirements": {
+                "ResetBios": {
+                    "Purpose": "Reset BIOS settings to their factory values.",
+                    "ReadRequirement": "Recommended"
+                }
+            }
+        },
+        "Chassis": {
+            "Purpose": "Allows collecting sensors data from the chassis.",
+            "ReadRequirement": "Recommended",
+            "PropertyRequirements": {
+                "Power": {
+                    "Purpose": "Provides a link to the power information.",
+                    "ReadRequirement": "Recommended",
+                    "Comparison": "LinkToResource",
+                    "Values": ["Power"]
+                },
+                "Thermal": {
+                    "Purpose": "Provides a link to the thermal information.",
+                    "ReadRequirement": "Recommended",
+                    "Comparison": "LinkToResource",
+                    "Values": ["Thermal"]
+                },
+                "UUID": {
+                    "Purpose": "Used as an ID for indicators.",
+                    "ReadRequirement": "Recommended"
+                }
+            }
+        },
+        "ComputerSystemCollection": {
+            "Purpose": "At least one system is expected.",
+            "PropertyRequirements": {
+                "Members": {
+                    "MinCount": 1
+                }
+            }
+        },
+        "ComputerSystem": {
+            "Purpose": "Provides bare-metal node management.",
+            "PropertyRequirements": {
+                "Bios": {
+                    "Purpose": "Reference to the corresponding Bios resource.",
+                    "ReadRequirement": "Recommended"
+                },
+                "BiosVersion": {
+                    "Purpose": "Version of the system firmware.",
+                    "ReadRequirement": "Recommended"
+                },
+                "Boot": {
+                    "Purpose": "Allows changing boot devices and modes, which is fundamental for bare-metal provisioning.",
+                    "PropertyRequirements": {
+                        "BootSourceOverrideEnabled": {
+                            "Purpose": "Manages whether the next boot device will be permanent or one-time.",
+                            "WriteRequirement": "Mandatory",
+                            "MinSupportValues": [
+                                "Once",
+                                "Continuous"
+                            ]
+                        },
+                        "BootSourceOverrideMode": {
+                            "Purpose": "Allows switching boot mode to/from UEFI.",
+                            "WriteRequirement": "Mandatory"
+                        },
+                        "BootSourceOverrideTarget": {
+                            "Purpose": "Allows changing the next boot device.",
+                            "WriteRequirement": "Mandatory",
+                            "MinSupportValues": [
+                                "Pxe",
+                                "Hdd",
+                                "Cd"
+                            ]
+                        }
+                    }
+                },
+                "EthernetInterfaces": {
+                    "Purpose": "Provides a link to the node's network interfaces.",
+                    "ReadRequirement": "Recommended",
+                    "Comparison": "LinkToResource",
+                    "Values": ["EthernetInterfaceCollection"]
+                },
+                "IndicatorLED": {
+                    "Purpose": "Enables the bare-metal indicator API.",
+                    "WriteRequirement": "Recommended",
+                    "ReadRequirement": "Recommended",
+                    "Comparison": "AnyOf",
+                    "Values": [
+                        "Lit",
+                        "Off",
+                        "Blinking"
+                    ]
+                },
+                "Links": {
+                    "PropertyRequirements": {
+                        "Chassis": {
+                            "Purpose": "Provides sensor data.",
+                            "ReadRequirement": "Recommended"
+                        },
+                        "ManagedBy": {
+                            "Purpose": "Provides a link from the node to its BMC."
+                        }
+                    }
+                },
+                "Manufacturer": {
+                    "Purpose": "Provides the 'vendor' property.",
+                    "ReadRequirement": "Recommended"
+                },
+                "MemorySummary": {
+                    "Purpose": "Provides memory data during out-of-band inspection.",
+                    "ReadRequirement": "Recommended",
+                    "PropertyRequirements": {
+                        "TotalSystemMemoryGiB": {}
+                    }
+                },
+                "PowerState": {
+                    "Purpose": "Provides the current power state."
+                },
+                "Processors": {
+                    "Purpose": "Provides a link to the node's CPUs.",
+                    "ReadRequirement": "Recommended",
+                    "Comparison": "LinkToResource",
+                    "Values": ["ProcessorCollection"]
+                },
+                "SecureBoot": {
+                    "Purpose": "Provides a link to the node's secure boot settings.",
+                    "ReadRequirement": "Recommended",
+                    "Comparison": "LinkToResource",
+                    "Values": ["SecureBoot"]
+                },
+                "SimpleStorage": {
+                    "Purpose": "Provides disk data during out-of-band inspection.",
+                    "ReadRequirement": "Recommended",
+                    "Comparison": "LinkToResource",
+                    "Values": ["SimpleStorageCollection"]
+                },
+                "Storage": {
+                    "Purpose": "Enables hardware RAID management.",
+                    "ReadRequirement": "Recommended",
+                    "Comparison": "LinkToResource",
+                    "Values": ["StorageCollection"]
+                },
+                "VirtualMedia": {
+                    "Purpose": "Enables provisioning using virtual media.",
+                    "ReadRequirement": "IfImplemented",
+                    "Comparison": "LinkToResource",
+                    "Values": ["VirtualMediaCollection"]
+                }
+            },
+            "ActionRequirements": {
+                "Reset": {
+                    "Purpose": "Provides an ability to execute power actions on the node.",
+                    "Parameters": {
+                        "ResetType": {
+                            "ParameterValues": [
+                                "On",
+                                "ForceOff",
+                                "ForceRestart"
+                            ],
+                            "RecommendedValues": [
+                                "GracefulShutdown",
+                                "GracefulRestart",
+                                "Nmi"
+                            ],
+                            "ReadRequirement": "Mandatory"
+                        }
+                    }
+                }
+            }
+        },
+        "Drive": {
+            "ReadRequirement": "Recommended",
+            "Purpose": "Provides information about individual drives when configuring hardware RAID.",
+            "PropertyRequirements": {
+                "CapacityBytes": {
+                    "ReadRequirement": "Recommended"
+                },
+                "MediaType": {},
+                "Protocol": {},
+                "Status": {
+                    "PropertyRequirements": {
+                        "Health": {},
+                        "State": {}
+                    }
+                }
+            }
+        },
+        "EthernetInterface": {
+            "Purpose": "Enables enrolling ports during inspection.",
+            "ReadRequirement": "Recommended",
+            "URIs": [
+                "/redfish/v1/Systems/{ComputerSystemId}/EthernetInterfaces/{EthernetInterfaceId}"
+            ],
+            "PropertyRequirements": {
+                "MACAddress": {
+                    "Purpose": "MAC address is mandatory on ports."
+                },
+                "Status": {
+                    "PropertyRequirements": {
+                        "Health": {
+                            "Purpose": "Only healthy interfaces are considered."
+                        },
+                        "State": {
+                            "Purpose": "Enables filtering only enabled interfaces."
+                        }
+                    }
+                }
+            }
+        },
+        "Manager": {
+            "Purpose": "Provides access to the properties of the BMC.",
+            "ReadRequirement": "Recommended",
+            "PropertyRequirements": {
+                "FirmwareVersion": {
+                    "Purpose": "Provides the current firmware version of the BMC.",
+                    "ReadRequirement": "Recommended"
+                }
+            }
+        },
+        "Power": {
+            "Purpose": "Provides the current power information in the sensor data.",
+            "ReadRequirement": "Recommended",
+            "PropertyRequirements": {
+                "PowerSupplies": {
+                    "Purpose": "Provides a list of the installed power supplies.",
+                    "PropertyRequirements": {
+                        "LastPowerOutputWatts": {
+                            "ReadRequirement": "Recommended"
+                        },
+                        "LineInputVoltage": {
+                            "ReadRequirement": "Recommended"
+                        },
+                        "PowerCapacityWatts": {
+                            "ReadRequirement": "Recommended"
+                        },
+                        "SerialNumber": {
+                            "ReadRequirement": "Recommended"
+                        },
+                        "Status": {
+                            "PropertyRequirements": {
+                                "Health": {
+                                    "Purpose": "Health status to report in the sensors data.",
+                                    "ReadRequirement": "Recommended"
+                                },
+                                "State": {
+                                    "Purpose": "Power state to report in the sensors data.",
+                                    "ReadRequirement": "Recommended"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "Processor": {
+            "Purpose": "Provides CPU data during out-of-band inspection.",
+            "ReadRequirement": "Recommended",
+            "PropertyRequirements": {
+                "ProcessorArchitecture": {
+                    "Purpose": "Used to determine the CPU architecture of the machine."
+                },
+                "TotalThreads": {
+                    "Purpose": "Used to estimate the core count."
+                }
+            }
+        },
+        "SecureBoot": {
+            "Purpose": "Allows turning secure boot mode on and off.",
+            "ReadRequirement": "Recommended",
+            "PropertyRequirements": {
+                "SecureBootEnable": {
+                    "Purpose": "Allows reading and changing the secure boot state.",
+                    "WriteRequirement": "Recommended"
+                }
+            },
+            "ActionRequirements": {
+                "ResetKeys": {
+                    "Purpose": "Allows resetting secure boot keys via a step.",
+                    "ReadRequirement": "Recommended"
+                }
+            }
+        },
+        "ServiceRoot": {
+            "Purpose": "Provides links to all collections and services.",
+            "PropertyRequirements": {
+                "Systems": {
+                    "Purpose": "Provides a link to systems.",
+                    "Comparison": "LinkToResource",
+                    "Values": ["ComputerSystemCollection"]
+                },
+                "SessionService": {
+                    "Purpose": "Provides a link to the session service.",
+                    "ReadRequirement": "Recommended",
+                    "Comparison": "LinkToResource",
+                    "Values": ["SessionService"]
+                },
+                "TaskService": {
+                    "Purpose": "Provides a link to the task service.",
+                    "ReadRequirement": "Recommended",
+                    "Comparison": "LinkToResource",
+                    "Values": ["TaskService"]
+                },
+                "UpdateService": {
+                    "Purpose": "Provides a link to the update service.",
+                    "ReadRequirement": "Recommended",
+                    "Comparison": "LinkToResource",
+                    "Values": ["UpdateService"]
+                }
+            }
+        },
+        "SessionService": {
+            "Purpose": "Allows using sessions for authentication instead of HTTP basic authentication.",
+            "ReadRequirement": "Recommended"
+        },
+        "SimpleStorage": {
+            "Purpose": "Provides information about disks during inspection as well as disk sensors.",
+            "ReadRequirement": "Recommended",
+            "PropertyRequirements": {
+                "Devices": {
+                    "PropertyRequirements": {
+                        "CapacityBytes": {
+                            "Purpose": "Disk capacity.",
+                            "ReadRequirement": "Recommended"
+                        },
+                        "Model": {
+                            "Purpose": "Device model to report in the sensors data.",
+                            "ReadRequirement": "Recommended"
+                        },
+                        "Name": {
+                            "Purpose": "Device name to report in the sensors data.",
+                            "ReadRequirement": "Recommended"
+                        },
+                        "Status": {
+                            "PropertyRequirements": {
+                                "Health": {
+                                    "Purpose": "Health status to report in the sensors data.",
+                                    "ReadRequirement": "Recommended"
+                                },
+                                "State": {
+                                    "Purpose": "Device state to report in the sensors data.",
+                                    "ReadRequirement": "Recommended"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "Storage": {
+            "Purpose": "Allows configuring hardware RAID.",
+            "ReadRequirement": "Recommended",
+            "MinVersion": "1.9.0",
+            "PropertyRequirements": {
+                "Drives": {
+                    "Purpose": "Provides attached drives as an inline array of Drive references."
+                },
+                "Controllers": {
+                    "Purpose": "Provides a link to the storage controllers.",
+                    "Comparison": "LinkToResource",
+                    "Values": ["StorageControllerCollection"],
+                    "ReplacesProperty": "StorageControllers"
+                },
+                "StorageControllers": {
+                    "ReadRequirement": "IfImplemented",
+                    "ReplacedByProperty": "Controllers",
+                    "Purpose": "Deprecated inline storage controllers; superseded by Controllers since Storage v1.9.0.",
+                    "MinCount": 1,
+                    "PropertyRequirements": {
+                        "SupportedRAIDTypes": {
+                            "ReadRequirement": "Recommended",
+                            "Purpose": "Defines which RAID types are supported."
+                        }
+                    }
+                },
+                "Volumes": {
+                    "Purpose": "Provides a link to existing volumes.",
+                    "Comparison": "LinkToResource",
+                    "Values": ["VolumeCollection"]
+                }
+            }
+        },
+        "StorageController": {
+            "Purpose": "Provides RAID controller capabilities when exposed as standalone resources.",
+            "ReadRequirement": "Recommended",
+            "PropertyRequirements": {
+                "SupportedRAIDTypes": {
+                    "ReadRequirement": "Recommended",
+                    "Purpose": "Defines which RAID types are supported."
+                }
+            }
+        },
+        "StorageControllerCollection": {
+            "Purpose": "Lists storage controllers for hardware RAID.",
+            "ReadRequirement": "IfImplemented",
+            "PropertyRequirements": {
+                "Members": {
+                    "MinCount": 1
+                }
+            }
+        },
+        "TaskService": {
+            "Purpose": "Provides task management.",
+            "ReadRequirement": "Recommended"
+        },
+        "Thermal": {
+            "Purpose": "Provides thermal information of a chassis as part of the sensors data.",
+            "ReadRequirement": "Recommended",
+            "MinVersion": "1.0.1",
+            "PropertyRequirements": {
+                "Fans": {
+                    "PropertyRequirements": {
+                        "MaxReadingRange": {
+                            "ReadRequirement": "Recommended"
+                        },
+                        "MinReadingRange": {
+                            "ReadRequirement": "Recommended"
+                        },
+                        "Reading": {},
+                        "ReadingUnits": {},
+                        "SerialNumber": {
+                            "ReadRequirement": "Recommended"
+                        },
+                        "Status": {
+                            "PropertyRequirements": {
+                                "Health": {
+                                    "Purpose": "Health status to report in the sensors data.",
+                                    "ReadRequirement": "Recommended"
+                                },
+                                "State": {
+                                    "Purpose": "Device state to report in the sensors data.",
+                                    "ReadRequirement": "Recommended"
+                                }
+                            }
+                        }
+                    }
+                },
+                "Temperatures": {
+                    "PropertyRequirements": {
+                        "MaxReadingRangeTemp": {
+                            "ReadRequirement": "Recommended"
+                        },
+                        "MinReadingRangeTemp": {
+                            "ReadRequirement": "Recommended"
+                        },
+                        "ReadingCelsius": {},
+                        "PhysicalContext": {
+                            "ReadRequirement": "Recommended"
+                        },
+                        "SensorNumber": {
+                            "ReadRequirement": "Recommended"
+                        }
+                    }
+                }
+            }
+        },
+        "UpdateService": {
+            "ReadRequirement": "Recommended",
+            "ActionRequirements": {
+                "SimpleUpdate": {
+                    "Purpose": "Enables firmware updates.",
+                    "Parameters": {
+                        "ImageURI": {},
+                        "Targets": {
+                            "ReadRequirement": "Recommended"
+                        },
+                        "TransferProtocol": {}
+                    }
+                }
+            }
+        },
+        "VirtualMedia": {
+            "Purpose": "Enables provisioning using virtual media.",
+            "PropertyRequirements": {
+                "Image": {
+                    "Purpose": "URL of the image to attach.",
+                    "WriteRequirement": "Recommended"
+                },
+                "Inserted": {
+                    "ReadRequirement": "Recommended",
+                    "WriteRequirement": "Recommended"
+                },
+                "MediaTypes": {
+                    "Purpose": "Supported media types for this virtual media slot."
+                },
+                "WriteProtected": {
+                    "ReadRequirement": "Recommended",
+                    "WriteRequirement": "Recommended"
+                }
+            },
+            "ActionRequirements": {
+                "EjectMedia": {
+                    "Purpose": "Enables ejecting virtual media devices."
+                },
+                "InsertMedia": {
+                    "Purpose": "Enables inserting virtual media devices.",
+                    "Parameters": {
+                        "Image": {},
+                        "Inserted": {
+                            "ReadRequirement": "Recommended"
+                        },
+                        "TransferMethod": {
+                            "ReadRequirement": "Recommended"
+                        },
+                        "TransferProtocolType": {
+                            "ReadRequirement": "Recommended"
+                        },
+                        "WriteProtected": {
+                            "ReadRequirement": "Recommended"
+                        }
+                    }
+                }
+            }
+        },
+        "Volume": {
+            "Purpose": "Provides access to RAID volumes.",
+            "ReadRequirement": "Recommended",
+            "MinVersion": "1.3.1",
+            "PropertyRequirements": {
+                "CapacityBytes": {},
+                "Name": {},
+                "RAIDType": {
+                    "ReadRequirement": "Recommended"
+                }
+            }
+        },
+        "VolumeCollection": {
+            "Purpose": "Allows listing and creating RAID volumes.",
+            "ReadRequirement": "Recommended",
+            "CreateResource": true,
+            "PropertyRequirements": {
+                "@Redfish.OperationApplyTimeSupport": {}
+            }
+        }
+    },
+    "Registries": {
+        "Base": {
+            "MinVersion": "1.0.0",
+            "Messages": {}
+        }
+    }
+}

--- a/hack/redfish/run-interop.sh
+++ b/hack/redfish/run-interop.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Runs the DMTF Redfish-Interop-Validator against the Redfish API served by
+# hack/redfish/interopserver (production read paths on in-memory fake clients).
+# Mirrors the "Validate PR head" step of .github/workflows/redfish-interop.yml.
+#
+# Paths are resolved from the repo root. Requires rf_interop_validator on PATH.
+# Exit status is the validator's (non-zero while profile gaps remain), unless
+# EXIT_WITH_VALIDATOR=0 — used by CI, which defers gating to the diff step and
+# must not let a failed validation skip the base run. Infrastructure failures
+# (build, readiness) always exit non-zero either way.
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+PROFILE=${PROFILE:-hack/redfish/profiles/OpenStackIronicProfile.v1_2_0.json}
+VALIDATOR_VERSION=${VALIDATOR_VERSION:-2.3.6}
+BMC_USER=admin
+BMC_PASSWORD=password
+BMC_URL=http://127.0.0.1:8000
+LOGDIR=${LOGDIR:-logs/local}
+EXIT_WITH_VALIDATOR=${EXIT_WITH_VALIDATOR:-1}
+
+if ! command -v rf_interop_validator >/dev/null; then
+	echo "rf_interop_validator not found; install with:" >&2
+	echo "  pip install 'redfish_interop_validator==${VALIDATOR_VERSION}'" >&2
+	exit 1
+fi
+
+tmpdir=$(mktemp -d)
+server_pid=""
+cleanup() {
+	[ -n "$server_pid" ] && kill "$server_pid" 2>/dev/null || true
+	rm -rf "$tmpdir"
+}
+trap cleanup EXIT
+
+go build -o "$tmpdir/interopserver" ./hack/redfish/interopserver
+"$tmpdir/interopserver" &
+server_pid=$!
+
+curl -sf --retry 30 --retry-delay 1 --retry-connrefused \
+	-u "$BMC_USER:$BMC_PASSWORD" "$BMC_URL/redfish/v1/" >/dev/null
+
+rm -rf "$LOGDIR"
+mkdir -p "$LOGDIR"
+status=0
+rf_interop_validator -i "$BMC_URL" -u "$BMC_USER" -p "$BMC_PASSWORD" \
+	--authtype Basic --forceauth --no_online_profiles \
+	--logdir "$LOGDIR" "$PROFILE" 2>&1 | tee "$LOGDIR/stdout.txt" || status=$?
+
+python3 hack/redfish/interop-diff.py "$LOGDIR"
+if [ "$EXIT_WITH_VALIDATOR" = "1" ]; then
+	exit "$status"
+fi


### PR DESCRIPTION
Serve the real emulator on in-memory fake clients (hack/redfish/interopserver), validate PR head vs base ref, and post a markdown diff of introduced/fixed errors to the step summary; full HTML reports as artifacts. Ironic's OpenStackIronicProfile v1.2.0 is vendored for offline runs.

This PR is a prerequisite for #275 
ref https://github.com/kubevirtbmc/kubevirtbmc/issues/70#issuecomment-2692337543