### PR TITLE
ci: integrate Codecov and add README badges

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,30 @@ on:
     - "v*"
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+    - name: Check out repository code
+      uses: actions/checkout@v4
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+    - name: Lint
+      run: make lint
+    - name: Run tests
+      run: make test
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@v7
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        slug: kubevirtbmc/kubevirtbmc
+        files: ./cover.out
+
   build-main:
+    needs: test
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -45,6 +45,12 @@ jobs:
       run: make lint
     - name: Run tests
       run: make test
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@v7
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        slug: kubevirtbmc/kubevirtbmc
+        files: ./cover.out
     - name: Build binaries
       run: make build
     # The docker daemon does not support tags pointing at a manifest list, rather than a manifest. Ref: https://github.com/docker/buildx/issues/59

--- a/README.md
+++ b/README.md
@@ -5,8 +5,11 @@
 </div>
 
 [![main build and publish workflow](https://github.com/kubevirtbmc/kubevirtbmc/actions/workflows/main.yml/badge.svg)](https://github.com/kubevirtbmc/kubevirtbmc/actions/workflows/main.yml)
+[![codecov](https://codecov.io/gh/kubevirtbmc/kubevirtbmc/graph/badge.svg?token=6U2WviF0iB)](https://codecov.io/gh/kubevirtbmc/kubevirtbmc)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/14432/badge)](https://www.bestpractices.dev/projects/14432)
+[![License](https://img.shields.io/github/license/kubevirtbmc/kubevirtbmc)](https://github.com/kubevirtbmc/kubevirtbmc/blob/main/LICENSE)
 [![release](https://img.shields.io/github/v/release/kubevirtbmc/kubevirtbmc)](https://github.com/kubevirtbmc/kubevirtbmc/releases)
-[![Discord](https://img.shields.io/discord/1436578911613091850?style=flat&label=Discord&color=7289da)](https://discord.gg/k5hT9GDQkY)
+[![Discord](https://img.shields.io/badge/Discord-join_chat-blue?style=social&logo=discord)](https://discord.gg/k5hT9GDQkY)
 
 KubeVirtBMC provides **out-of-band management** for [KubeVirt](https://github.com/kubevirt/kubevirt) virtual machines on Kubernetes via [IPMI](https://www.intel.com.tw/content/www/tw/zh/products/docs/servers/ipmi/ipmi-second-gen-interface-spec-v2-rev1-1.html) and [Redfish](https://www.dmtf.org/standards/redfish)—power on/off, reset, and set boot device. Built for [Tinkerbell](https://github.com/tinkerbell/tink)/[Seeder](https://github.com/harvester/seeder) and compatible with any tooling that speaks IPMI or Redfish.
 


### PR DESCRIPTION
- Upload coverage reports (`cover.out`) to Codecov after `make test` in both the PR and main build workflow
- Add Codecov, OpenSSF Best Practices, and License badges to the README
- Restyle the Discord badge
