### PR TITLE
fix(redfish): implement SessionCollection GET to stop 404/405 flip

### DIFF
--- a/pkg/redfish/api_service.go
+++ b/pkg/redfish/api_service.go
@@ -53816,16 +53816,7 @@ func (s *APIService) RedfishV1SessionServicePatch(ctx context.Context, sessionSe
 
 // RedfishV1SessionServiceSessionsGet -
 func (s *APIService) RedfishV1SessionServiceSessionsGet(ctx context.Context) (server.ImplResponse, error) {
-	// TODO - update RedfishV1SessionServiceSessionsGet with the required logic for this service method.
-	// Add api_default_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-
-	// TODO: Uncomment the next line to return response Response(200, SessionCollectionSessionCollection{}) or use other options such as http.Ok ...
-	// return Response(200, SessionCollectionSessionCollection{}), nil
-
-	// TODO: Uncomment the next line to return response Response(0, RedfishError{}) or use other options such as http.Ok ...
-	// return Response(0, RedfishError{}), nil
-
-	return server.Response(http.StatusNotImplemented, nil), errors.New("RedfishV1SessionServiceSessionsGet method not implemented")
+	return server.Response(200, s.handler.GetSessionCollection()), nil
 }
 
 // RedfishV1SessionServiceSessionsPost -
@@ -53848,8 +53839,8 @@ func (s *APIService) RedfishV1SessionServiceSessionsPost(ctx context.Context, se
 	}
 
 	return server.Response(201, server.SessionV171Session{
-		OdataType: "Session.v1_7_1.Session",
-		OdataId:   "/redfish/v1/SessionService/Sessions/1",
+		OdataType: "#Session.v1_7_1.Session",
+		OdataId:   fmt.Sprintf("/redfish/v1/SessionService/Sessions/%s", id),
 		Id:        id,
 		Name:      "User Session",
 		Token:     &token, // The final response will not contain this field. It's just a means to pass the token to the caller.
@@ -53874,7 +53865,7 @@ func (s *APIService) RedfishV1SessionServiceSessionsSessionIdGet(ctx context.Con
 	}
 
 	return server.Response(200, server.SessionV171Session{
-		OdataType: "Session.v1_7_1.Session",
+		OdataType: "#Session.v1_7_1.Session",
 		OdataId:   fmt.Sprintf("/redfish/v1/SessionService/Sessions/%s", id),
 		Id:        id,
 		Name:      "User Session",

--- a/pkg/redfish/handler.go
+++ b/pkg/redfish/handler.go
@@ -56,8 +56,27 @@ func (h *handler) GetSession(sessionID string) (string, string, error) {
 	return tokenInfo.ID, tokenInfo.Username, nil
 }
 
+func (h *handler) GetSessionCollection() *server.SessionCollectionSessionCollection {
+	tokens := session.ListTokens()
+	members := make([]server.OdataV4IdRef, 0, len(tokens))
+	for _, t := range tokens {
+		members = append(members, server.OdataV4IdRef{
+			OdataId: fmt.Sprintf("/redfish/v1/SessionService/Sessions/%s", t.ID),
+		})
+	}
+	return &server.SessionCollectionSessionCollection{
+		OdataContext:      "/redfish/v1/$metadata#SessionCollection.SessionCollection",
+		OdataId:           "/redfish/v1/SessionService/Sessions",
+		OdataType:         "#SessionCollection.SessionCollection",
+		Description:       "Session Collection",
+		Name:              "Session Collection",
+		Members:           members,
+		MembersodataCount: int64(len(members)),
+	}
+}
+
 func (h *handler) DeleteSession(sessionID string) {
-	session.RemoveToken(sessionID)
+	session.RemoveTokenBySessionID(sessionID)
 }
 
 func (h *handler) GetServiceRoot() *server.ServiceRootV1161ServiceRoot {

--- a/pkg/redfish/handler_test.go
+++ b/pkg/redfish/handler_test.go
@@ -140,6 +140,29 @@ func TestGetSession(t *testing.T) {
 	}
 }
 
+func TestGetSessionCollection(t *testing.T) {
+	ctl := gomock.NewController(t)
+	defer ctl.Finish()
+
+	h := NewHandler(testUsername, testPassword, nil)
+
+	tokenInfo := session.NewTokenInfo("test-session-id-collection", testUsername)
+	token := session.AddToken(tokenInfo)
+	defer session.RemoveToken(token)
+
+	collection := h.GetSessionCollection()
+	assert.Equal(t, "/redfish/v1/SessionService/Sessions", collection.OdataId)
+	assert.Equal(t, int64(len(collection.Members)), collection.MembersodataCount)
+
+	found := false
+	for _, member := range collection.Members {
+		if member.OdataId == "/redfish/v1/SessionService/Sessions/test-session-id-collection" {
+			found = true
+		}
+	}
+	assert.True(t, found, "session collection should contain the added session")
+}
+
 func TestDeleteSession(t *testing.T) {
 	ctl := gomock.NewController(t)
 	defer ctl.Finish()
@@ -173,7 +196,7 @@ func TestDeleteSession(t *testing.T) {
 			}
 
 			h.DeleteSession(tc.sessionID)
-			_, exists := session.GetToken(tc.sessionID)
+			_, exists := session.GetTokenFromSessionID(tc.sessionID)
 			assert.False(t, exists)
 		})
 	}

--- a/pkg/redfish/implemented_routes_gen.go
+++ b/pkg/redfish/implemented_routes_gen.go
@@ -15,6 +15,7 @@ var implementedMethods = map[string]bool{
 	"RedfishV1ManagersManagerIdVirtualMediaVirtualMediaIdActionsVirtualMediaEjectMediaPost":  true,
 	"RedfishV1ManagersManagerIdVirtualMediaVirtualMediaIdActionsVirtualMediaInsertMediaPost": true,
 	"RedfishV1ManagersManagerIdVirtualMediaVirtualMediaIdGet":                                true,
+	"RedfishV1SessionServiceSessionsGet":                                                     true,
 	"RedfishV1SessionServiceSessionsPost":                                                    true,
 	"RedfishV1SessionServiceSessionsSessionIdDelete":                                         true,
 	"RedfishV1SessionServiceSessionsSessionIdGet":                                            true,

--- a/pkg/redfish/implemented_routes_test.go
+++ b/pkg/redfish/implemented_routes_test.go
@@ -22,6 +22,7 @@ func TestBaseRouteName(t *testing.T) {
 func TestImplementedMethods(t *testing.T) {
 	for _, name := range []string{
 		"RedfishV1Get",
+		"RedfishV1SessionServiceSessionsGet",
 		"RedfishV1SessionServiceSessionsPost",
 		"RedfishV1SystemsComputerSystemIdGet",
 		"RedfishV1SystemsComputerSystemIdActionsComputerSystemResetPost",

--- a/pkg/session/token.go
+++ b/pkg/session/token.go
@@ -74,6 +74,20 @@ func RemoveToken(token string) {
 	delete(ts.store, token)
 }
 
+// RemoveTokenBySessionID deletes the session with the given ID. The Redfish
+// DELETE on a session resource addresses it by session ID, while the store is
+// keyed by token.
+func RemoveTokenBySessionID(sessionID string) {
+	ts.rwMutex.Lock()
+	defer ts.rwMutex.Unlock()
+
+	for token, tokenInfo := range ts.store {
+		if tokenInfo.ID == sessionID {
+			delete(ts.store, token)
+		}
+	}
+}
+
 func GetTokenFromSessionID(sessionID string) (TokenInfo, bool) {
 	ts.rwMutex.RLock()
 	defer ts.rwMutex.RUnlock()
@@ -85,6 +99,19 @@ func GetTokenFromSessionID(sessionID string) (TokenInfo, bool) {
 	}
 
 	return TokenInfo{}, false
+}
+
+// ListTokens returns a snapshot of every live session, for building the
+// Redfish session collection.
+func ListTokens() []TokenInfo {
+	ts.rwMutex.RLock()
+	defer ts.rwMutex.RUnlock()
+
+	tokens := make([]TokenInfo, 0, len(ts.store))
+	for _, tokenInfo := range ts.store {
+		tokens = append(tokens, tokenInfo)
+	}
+	return tokens
 }
 
 func AuthMiddleware(bmcUser, bmcPassword string) func(next http.Handler) http.Handler {


### PR DESCRIPTION
fix https://github.com/kubevirtbmc/kubevirtbmc/issues/311

## Root cause

Since #269 stripped unimplemented routes, `RedfishV1SessionServiceSessionsGet` (a 501 stub) has no route while `SessionsPost` on the same path stays registered. gorilla/mux registers routes by iterating a map, so the outcome for GET on that path is decided per process start:

- the POST route records `ErrMethodMismatch` for the GET request;
- but any *later-registered* GET route whose method matcher succeeds clears `MatchErr` again (`route.go`), downgrading to 404.

Only when the POST route lands last among the unprotected routes does 405 survive (~1/3 of process starts; measured 21×405 / 29×404 over 50 router builds). The interop CI diffs base vs. head by exact validator message, so two runs of identical code rolling different statuses shows up as a phantom "introduced" failure — e.g. https://github.com/kubevirtbmc/kubevirtbmc/actions/runs/34670917882 on #298.

## Fix

Implement `RedfishV1SessionServiceSessionsGet` for real: list the live sessions from the token store. The endpoint now deterministically answers 200 with a valid `SessionCollection`, so the validator failure disappears from both base and head runs and the gate settles. (Making the stripped stubs answer 501 was rejected: it would still change the message vs. base and fail the gate on this very PR; normalizing status codes in interop-diff would only hide the server-side nondeterminism.)

Building the collection surfaced three pre-existing inconsistencies it would otherwise expose, fixed in the same commit:

- `DELETE /SessionService/Sessions/{id}` was a no-op — it passed the session ID to `RemoveToken`, which keys on the token. Terminated sessions kept authenticating and would have stayed listed. Now removed by session ID.
- `SessionsPost` hardcoded the body `@odata.id` to `.../Sessions/1` (never resolvable) while the `Location` header carried the real ID — aligned with the header.
- Session payloads used `Session.v1_7_1.Session` without the `#` the OData type URL requires (DSP0266) — every other resource has it.

Also fixed `TestDeleteSession`, which asserted via `GetToken(sessionID)` and therefore passed vacuously.

## Testing

- `TestGetSessionCollection` + fixed `TestDeleteSession`; `go build/vet/test ./pkg/...` green.
- Determinism: 50 router builds → 50×401 (no auth) / 50×200 (basic auth); previously 29×404 / 21×405.
- End-to-end against `hack/redfish/interopserver`: POST → collection lists the member with the canonical URI; member GET 200; DELETE → 204; afterwards member GET 404, collection empty, old token 401.
- The validator runs with `authtype=Basic, forceauth=True` and never creates sessions, so it sees a stable empty collection and the `could not be acquired` failure is simply gone.